### PR TITLE
Update Notifications.md

### DIFF
--- a/PayLink/README.md
+++ b/PayLink/README.md
@@ -57,7 +57,7 @@ as child elements of other objects.
 ### Notifications
 * [Resend PayLink Notification Email](/PayLink/Sections/Notifications.md#resend-paylink-notifiation-email)
 * [Resend PayLink Notification SMS](/PayLink/Sections/Notifications.md#resend-paylink-notification-sms)
-* [Retrieve SMS Notification Templates](/PayLink/Sections/Notifications.md#retrieve-sms-notification-templates)
+* [Retrieve Notification Templates](/PayLink/Sections/Notifications.md#retrieve-notification-templates)
 
 ### Templates
 * [Create Template](https://github.com/PayFabric/APIs/blob/master/PayLink/Sections/Templates.md#create-template-for-specific-template-type)

--- a/PayLink/Sections/Email and SMS Templates.md
+++ b/PayLink/Sections/Email and SMS Templates.md
@@ -20,7 +20,6 @@ The JSON payload sent during the API's exposes a [Notification object](JSON%20Ob
 If no template name is provided the default as defined in the PayLink portal will be used.  If a template name is provided that does not match a template, the Payment Link or Wallet Link will still be created however, a warning message will be included in the Notification ResponseMessage field indication the template did not match.
 
 ## Additional APIs
-There are two additional APIs provided for Email and SMS Templates, you may find them here:
+There is an additional API provided for Email and SMS Templates, you may find it here:
 
-* [Retrieve Email Templates](Notifications.md#retrieve-email-notification-templates)
-* [Retrieve SMS Templates](Notifications.md#retrieve-sms-notification-templates)
+* [Retrieve Notification Templates](Notifications.md#retrieve-notification-templates)

--- a/PayLink/Sections/Notifications.md
+++ b/PayLink/Sections/Notifications.md
@@ -25,10 +25,11 @@ A failed `POST` may result in a HTTP 400 Bad Request Response if the notificatio
 A failed `POST` may result in a HTTP 404 Not Found Response if the specified document does not exist or the Device ID used for the *Security Token* does not match.  
 A failed `POST` may result in a HTTP 405 Method Not Allowed Response if the specified document status is not 1.  
 
-Retrieve SMS Notification Templates
+Retrieve Email/SMS Notification Templates
 -----------------------------------
 
-* `GET /paylink/api/notification/sms/templates` will return all SMS notification templates configured in the PayLink portal
+* `GET /paylink/api/notification/{Notification Type}/templates` will return either all Email or SMS notification templates configured in the PayLink portal.
+* Notification Type should be either `email` or `sms`.
 
 ###### Related Reading
 * [How to Create Notification Templates](../../../../Portal/blob/master/Sections/Features.md#templates)

--- a/PayLink/Sections/Notifications.md
+++ b/PayLink/Sections/Notifications.md
@@ -25,11 +25,11 @@ A failed `POST` may result in a HTTP 400 Bad Request Response if the notificatio
 A failed `POST` may result in a HTTP 404 Not Found Response if the specified document does not exist or the Device ID used for the *Security Token* does not match.  
 A failed `POST` may result in a HTTP 405 Method Not Allowed Response if the specified document status is not 1.  
 
-Retrieve Email/SMS Notification Templates
+Retrieve Notification Templates
 -----------------------------------
 
 * `GET /paylink/api/notification/{Notification Type}/templates` will return either all Email or SMS notification templates configured in the PayLink portal.
-* Notification Type should be either `email` or `sms`.
+* `Notification Type` should be either `email` or `sms`.
 
 ###### Related Reading
 * [How to Create Notification Templates](../../../../Portal/blob/master/Sections/Features.md#templates)


### PR DESCRIPTION
Retrieve SMS Notification Templates should be updated to also include Email templates. This page is linked from another document that claims that this document contains how to Retrieve Email Templates, and the API is similar enough to combine them.

(Document that links to this page for context: https://github.com/PayFabric/APIs/blob/master/PayLink/Sections/Email%20and%20SMS%20Templates.md#additional-apis)